### PR TITLE
Fix overlinking in SWIG python library

### DIFF
--- a/recipe/install-python.sh
+++ b/recipe/install-python.sh
@@ -22,7 +22,7 @@ ${SRC_DIR}/configure \
 ;
 
 # patch out dependency_libs from libtool archive to prevent overlinking
-sed -i '/^dependency_libs/d' lib/lib${PKG_NAME##*-}.la
+sed -i.tmp '/^dependency_libs/d' lib/lib${PKG_NAME##*-}.la
 
 # build
 make -j ${CPU_COUNT} V=1 VERBOSE=1 -C swig LIBS=""

--- a/recipe/install-python.sh
+++ b/recipe/install-python.sh
@@ -21,9 +21,12 @@ ${SRC_DIR}/configure \
 	--prefix=$PREFIX \
 ;
 
+# patch out dependency_libs from libtool archive to prevent overlinking
+sed -i '/^dependency_libs/d' lib/lib${PKG_NAME##*-}.la
+
 # build
-make -j ${CPU_COUNT} V=1 VERBOSE=1 -C swig
-make -j ${CPU_COUNT} V=1 VERBOSE=1 -C python
+make -j ${CPU_COUNT} V=1 VERBOSE=1 -C swig LIBS=""
+make -j ${CPU_COUNT} V=1 VERBOSE=1 -C python LIBS=""
 
 # install
 make -j ${CPU_COUNT} V=1 VERBOSE=1 -C swig install-exec  # swig bindings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -104,7 +104,7 @@ outputs:
         - test/python
         - test/F-TEST-*.gwf
       commands:
-        - python -m pytest -rs -v --junit-xml=junit.xml test/python
+        - python -m pytest -rs -v test/python
     about:
       home: https://wiki.ligo.org/Computing/LALSuite
       doc_url: https://lscsoft.docs.ligo.org/lalsuite/lalframe/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -90,9 +90,6 @@ outputs:
         - numpy
         - python
       run:
-        - ldas-tools-framecpp >={{ framecpp_version }}  # [linux]
-        - libframel >={{ framel_version }}  # [linux]
-        - liblal >={{ lal_version }}
         - {{ pin_subpackage('liblalframe', exact=True) }}
         - {{ pin_compatible('numpy') }}
         - python


### PR DESCRIPTION
This PR fixes the annoying overlinking issues in the SWIG python library.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
