### PR TITLE
Add run_constrained

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,7 @@ ${SRC_DIR}/configure \
 	--disable-swig-python \
 	--enable-framec \
 	--enable-framel \
+	--enable-help2man \
 	--enable-swig-iface \
 	--prefix="${PREFIX}" \
 ;

--- a/recipe/install-python.sh
+++ b/recipe/install-python.sh
@@ -16,6 +16,7 @@ ${SRC_DIR}/configure \
 	--disable-doxygen \
 	--disable-gcc-flags \
 	--disable-swig-iface \
+	--enable-help2man \
 	--enable-python \
 	--enable-swig-python \
 	--prefix=$PREFIX \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,6 +85,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - help2man >=1.37
         - make
         - pkg-config
         - swig >={{ swig_version }}
@@ -128,6 +129,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - help2man >=1.37
         - make
       host:
         - liblal >={{ lal_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,6 +98,8 @@ outputs:
         - {{ pin_compatible('numpy') }}
         - python
         - python-lal >={{ lal_version }}
+        # swig bindings cause segmentation fault
+        - numpy <1.20.0a0
     test:
       imports:
         - lalframe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:
@@ -53,6 +53,9 @@ outputs:
         - ldas-tools-framecpp >={{ framecpp_version }}
         - libframel >={{ framel_version }}
         - liblal >={{ lal_version }}
+      run_constrained:
+        - lalframe >=1.5.3
+        - python-lalframe >=1.5.3
     test:
       requires:
         - pkg-config


### PR DESCRIPTION
This PR adds a missing `run_constrained` metadata option to make sure you can't install liblalframe alongside older lalframes, which will conflict.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
